### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,13 @@ To setup core for a new project:
   3. Add the following to the `makefile`: `INC += -Ivendor/eigen`
 
 Or, you can use the [template](https://github.com/RIT-VEX-U/RobotTemplate) from the RIT VEX U organization.
+On the first clone of a project, run
+```
+git submodule init
+git submodule update
+```
+to initialize 3rd party dependencies.
+
 
 If you only wish to use a single version of Core, you can simply clone core/ into your project and add the core source and header files to your makefile.
 

--- a/README.md
+++ b/README.md
@@ -17,10 +17,13 @@ To setup core for a new project:
 2. Initialize a git repository for the project
 3. Execute `git subtree add --prefix=core git@github.com:RIT-VEX-U/Core.git main`
 4. Update the vex Makefile (or any other build system) to know about the core files (`core/src` for source files, `core/include` for headers)
-5. Enable [Eigen](https://eigen.tuxfamily.org/index.php?title=Main_Page):
+5. Enable [Eigen](https://eigen.tuxfamily.org/index.php?title=Main_Page) (Latest supported version is 3.4.0):
   1. `mkdir vendor`
-  2. git submodule add https://gitlab.com/libeigen/eigen.git vendor/eigen
-  3. Add the following to the `makefile`: `INC += -Ivendor/eigen`
+  2. `git submodule add https://gitlab.com/libeigen/eigen.git vendor/eigen`
+  3. `cd vendor/eigen`
+  4. `git checkout 3.4.0`
+  5. Add the following to the `makefile` to give Core access to the library: `INC += -Ivendor/eigen`
+
 
 Or, you can use the [template](https://github.com/RIT-VEX-U/RobotTemplate) from the RIT VEX U organization.
 On the first clone of a project, run

--- a/README.md
+++ b/README.md
@@ -9,29 +9,19 @@ There is also a downloadable [reference manual](https://rit-vex-u.github.io/Core
 
 ## Getting Started
 
+If you just want to start a project with Core, make a fork of the [Fork Template](https://github.com/RIT-VEX-U/ForkTemplate) and follow it's instructions.
 
-The recommended way to use this repo is through [git subtree](https://git-memo.readthedocs.io/en/latest/subtree.html).
-
-To setup core for a new project:
+To setup core for an existing project:
 1. Create a new vex project (using the VSCode extension or other methods)
 2. Initialize a git repository for the project
 3. Execute `git subtree add --prefix=core git@github.com:RIT-VEX-U/Core.git main`
-4. Update the vex Makefile (or any other build system) to know about the core files (`core/src` for source files, `core/include` for headers)
+4. Update the vex Makefile (or any other build system) to know about the core files (`core/src` for source files, `core/include` for headers) (See [here](https://github.com/RIT-VEX-U/ForkTemplate/blob/a3f64236c0c98512b95327c833e8a8c05724bb7c/makefile#L15) for an example) 
 5. Enable [Eigen](https://eigen.tuxfamily.org/index.php?title=Main_Page) (Latest supported version is 3.4.0):
-  1. `mkdir vendor`
-  2. `git submodule add https://gitlab.com/libeigen/eigen.git vendor/eigen`
-  3. `cd vendor/eigen`
-  4. `git checkout 3.4.0`
-  5. Add the following to the `makefile` to give Core access to the library: `INC += -Ivendor/eigen`
-
-
-Or, you can use the [template](https://github.com/RIT-VEX-U/RobotTemplate) from the RIT VEX U organization.
-On the first clone of a project, run
-```
-git submodule init
-git submodule update
-```
-to initialize 3rd party dependencies.
+    - `mkdir vendor`
+    - `git submodule add https://gitlab.com/libeigen/eigen.git vendor/eigen`
+    - `cd vendor/eigen`
+    - `git checkout 3.4.0`
+    - Add the following to the `makefile` to give Core access to the library: `INC += -Ivendor/eigen` (See [here](https://github.com/RIT-VEX-U/ForkTemplate/blob/a3f64236c0c98512b95327c833e8a8c05724bb7c/makefile#L34) for an example)
 
 
 If you only wish to use a single version of Core, you can simply clone core/ into your project and add the core source and header files to your makefile.


### PR DESCRIPTION
# Description
Updates the README to explain the new way to set up Core as part of a project. 
Additionally, [ForkTemplate](https://github.com/RIT-VEX-U/ForkTemplate) was created to supersede [RobotTemplate](https://github.com/RIT-VEX-U/RobotTemplate) as github templates do not preserve git history which git subtree requires to function. 

# Testing

ForkTemplate has a recent version of Core that compiles and passes CI. It was set up using these instructions.
