### PR TITLE
CobsSerialDevice

### DIFF
--- a/include/devices/cobs_serial_device.h
+++ b/include/devices/cobs_serial_device.h
@@ -1,0 +1,56 @@
+#pragma once
+#include <cstdint>
+#include <deque>
+#include <functional>
+#include <vector>
+#include <vex.h>
+
+class COBSSerialDevice {
+  public:
+    using WirePacket = std::vector<uint8_t>; // 0x00 delimeted, cobs encoded
+    using Packet = std::vector<uint8_t>;
+
+    static constexpr int32_t NO_ACTIVITY_DELAY_MS = 2;
+    static constexpr std::size_t MAX_OUT_QUEUE_SIZE = 50;
+    static constexpr std::size_t MAX_IN_QUEUE_SIZE = 50;
+
+    bool send_cobs_packet(const Packet &pac);
+
+  protected:
+    COBSSerialDevice(int32_t port, int32_t baud_rate);
+    virtual ~COBSSerialDevice() {}
+
+    virtual void cobs_packet_callback(const Packet &pac) = 0;
+
+  private:
+    int32_t port;
+    int32_t baud_rate;
+
+    /// @brief Packets that have been encoded and are waiting for their turn
+    /// to be sent out on the wire
+    std::deque<WirePacket> outbound_packets{};
+    vex::mutex outbound_mutex;
+
+    /// @brief Packets that have been read from the wire and split up but that are
+    /// still COBS encoded
+    std::deque<WirePacket> inbound_packets;
+    vex::mutex inbound_mutex;
+    /// @brief Working buffer that the reading thread uses to assemble packets
+    /// until it finds a full COBS packet
+    WirePacket inbound_buffer;
+
+    static void cobs_encode(const Packet &in, WirePacket &out, bool add_start_delimeter = false);
+    static void cobs_decode(const WirePacket &in, Packet &out);
+    void handle_inbound_byte(uint8_t b);
+    bool write_packet_if_avail();
+
+    // Task that deals with the low level writing and reading bytes from the wire
+    vex::task serial_task;
+    static int serial_thread(void *self);
+
+    // Once the serial_task has read in an entire packet, it must be decoded
+    // this thread decodes it back into its original binary form and calls the
+    // user callback
+    vex::task decode_task;
+    static int decode_thread(void *self);
+};

--- a/include/devices/cobs_serial_device.h
+++ b/include/devices/cobs_serial_device.h
@@ -14,16 +14,61 @@ class COBSSerialDevice {
     static constexpr std::size_t MAX_OUT_QUEUE_SIZE = 50;
     static constexpr std::size_t MAX_IN_QUEUE_SIZE = 50;
 
-    bool send_cobs_packet(const Packet &pac);
+    /**
+     * Send a packet to the device
+     * @param pac the non-encoded packet to send. It will be cobs encoded then sent
+     * @param add_front_delimeter whether or not to add a 0 byte before the packet. May help deliver a packet if the
+     * previous packet was corrupted
+     * @return true if the packet was sent. false if the queue was full and the packet can't be sent
+     */
+    bool send_cobs_packet(const Packet &pac, bool add_front_delimeter = false);
 
   protected:
+    /**
+     * @param port the port that the peripheral is on (vex::PORTX)
+     * @param baud_rate the baud rate of the serial communication
+     */
     COBSSerialDevice(int32_t port, int32_t baud_rate);
+    
     virtual ~COBSSerialDevice() {}
 
+    /**
+     * Callback when a packet comes in
+     * Overload this with your child class to have this called when a packet comes in
+     * @param pac the decoded packet that has been received
+     */
     virtual void cobs_packet_callback(const Packet &pac) = 0;
 
   private:
+    /**
+     * Encode a packet using consistent overhead byte stuffing
+     * @param[in] in the data to send
+     * @param[out] out the buffer to write the packet into
+     * @param add_start_delimeter whether or not to add a leading delimeter to the packet. Adding a start delimeter may
+     * help recover the system if the previous packet failed to completely send.
+     */
+    static void cobs_encode(const Packet &in, WirePacket &out, bool add_start_delimeter = false);
+    /**
+     * Decode a cobs encoded packet
+     * @param[in] in the packet recieved from the wire (without delimeters)
+     * @param[out] out the buffer to write the data into
+     */
+    static void cobs_decode(const WirePacket &in, Packet &out);
+    /**
+     * Handle byte recieved from the wire. Will build up a packet until a delimeter is reached then send it to be
+     * decoded
+     * @param b the byte received
+     */
+    void handle_inbound_byte(uint8_t b);
+    /**
+     * Write a packet to the serial device if one is waiting in the queue
+     * @return true if a packet was written
+     */
+    bool write_packet_if_avail();
+
+    /// @brief Port on which the device is initialized
     int32_t port;
+    /// @brief baud rate at which the device is running
     int32_t baud_rate;
 
     /// @brief Packets that have been encoded and are waiting for their turn
@@ -38,11 +83,6 @@ class COBSSerialDevice {
     /// @brief Working buffer that the reading thread uses to assemble packets
     /// until it finds a full COBS packet
     WirePacket inbound_buffer;
-
-    static void cobs_encode(const Packet &in, WirePacket &out, bool add_start_delimeter = false);
-    static void cobs_decode(const WirePacket &in, Packet &out);
-    void handle_inbound_byte(uint8_t b);
-    bool write_packet_if_avail();
 
     // Task that deals with the low level writing and reading bytes from the wire
     vex::task serial_task;

--- a/include/devices/cobs_serial_device.h
+++ b/include/devices/cobs_serial_device.h
@@ -23,23 +23,6 @@ class COBSSerialDevice {
      */
     bool send_cobs_packet(const Packet &pac, bool add_front_delimeter = false);
 
-  protected:
-    /**
-     * @param port the port that the peripheral is on (vex::PORTX)
-     * @param baud_rate the baud rate of the serial communication
-     */
-    COBSSerialDevice(int32_t port, int32_t baud_rate);
-    
-    virtual ~COBSSerialDevice() {}
-
-    /**
-     * Callback when a packet comes in
-     * Overload this with your child class to have this called when a packet comes in
-     * @param pac the decoded packet that has been received
-     */
-    virtual void cobs_packet_callback(const Packet &pac) = 0;
-
-  private:
     /**
      * Encode a packet using consistent overhead byte stuffing
      * @param[in] in the data to send
@@ -54,6 +37,24 @@ class COBSSerialDevice {
      * @param[out] out the buffer to write the data into
      */
     static void cobs_decode(const WirePacket &in, Packet &out);
+
+  protected:
+    /**
+     * @param port the port that the peripheral is on (vex::PORTX)
+     * @param baud_rate the baud rate of the serial communication
+     */
+    COBSSerialDevice(int32_t port, int32_t baud_rate);
+
+    virtual ~COBSSerialDevice() {}
+
+    /**
+     * Callback when a packet comes in
+     * Overload this with your child class to have this called when a packet comes in
+     * @param pac the decoded packet that has been received
+     */
+    virtual void cobs_packet_callback(const Packet &pac) = 0;
+
+  private:
     /**
      * Handle byte recieved from the wire. Will build up a packet until a delimeter is reached then send it to be
      * decoded

--- a/src/devices/cobs_serial_device.cpp
+++ b/src/devices/cobs_serial_device.cpp
@@ -1,0 +1,234 @@
+#include "../core/include/devices/cobs_serial_device.h"
+
+COBSSerialDevice::COBSSerialDevice(int32_t port, int32_t baud_rate)
+    : port(port), baud_rate(baud_rate), outbound_packets() {
+
+    serial_task = vex::task(COBSSerialDevice::serial_thread, (void *)this, vex::thread::threadPriorityHigh);
+    decode_task = vex::task(COBSSerialDevice::decode_thread, (void *)this, vex::thread::threadPriorityHigh);
+}
+
+void COBSSerialDevice::handle_inbound_byte(uint8_t b) {
+
+    if (b == 0x00 && inbound_buffer.size() > 0) {
+        if (inbound_packets.size() < MAX_IN_QUEUE_SIZE) {
+            inbound_packets.push_front(inbound_buffer);
+        } else {
+            printf(
+              "COBSSerialDevice Port%d: Dropping inbound packet. inbound queue "
+              "full\n",
+              (int)(port + 1)
+            );
+        }
+        // Starting a new packet now
+        inbound_buffer.clear();
+    } else if (b != 0x00) {
+        inbound_buffer.push_back(b);
+    }
+}
+
+int COBSSerialDevice::decode_thread(void *vself) {
+
+    COBSSerialDevice &self = *(COBSSerialDevice *)vself;
+    Packet decoded = {};
+
+    while (true) {
+
+        WirePacket inbound = {};
+        {
+            self.inbound_mutex.lock();
+
+            if (self.inbound_packets.size() > 0) {
+                inbound = self.inbound_packets.back();
+                self.inbound_packets.pop_back();
+            }
+            self.inbound_mutex.unlock();
+        }
+        // Theres no packet to decode
+        if (inbound.size() == 0) {
+            vexDelay(NO_ACTIVITY_DELAY_MS);
+            continue;
+        }
+
+        cobs_decode(inbound, decoded);
+
+        self.cobs_packet_callback(decoded);
+    }
+    return 0;
+}
+
+bool COBSSerialDevice::write_packet_if_avail() {
+    bool did_write = false;
+    WirePacket outbound_packet = {};
+
+    outbound_mutex.lock();
+    if (outbound_packets.size() > 0) {
+        outbound_packet = outbound_packets.back();
+        outbound_packets.pop_back();
+    }
+    outbound_mutex.unlock();
+    if (outbound_packet.size() == 0) {
+        return did_write;
+    }
+    const int avail = vexGenericSerialWriteFree(port);
+    if (avail < (int)outbound_packet.size()) {
+        // avail can be -1 for unknown reasons.
+        // Signed comparison handles this correctly (as
+        // correctly as I can think to).
+        vexGenericSerialFlush(port);
+    }
+    const int32_t wrote = vexGenericSerialTransmit(port, outbound_packet.data(), (int32_t)outbound_packet.size());
+    if (wrote < (int32_t)outbound_packet.size()) {
+        printf("Unhandled state: Didn't write all that we wanted to, will "
+               "probably get packet corruption\n");
+    }
+    did_write = true;
+
+    return did_write;
+}
+
+int COBSSerialDevice::serial_thread(void *vself) {
+    COBSSerialDevice &self = *(COBSSerialDevice *)vself;
+    vexDelay(1000);
+    vexGenericSerialEnable(self.port, 0x0);
+    vexGenericSerialBaudrate(self.port, self.baud_rate);
+
+    static constexpr size_t buflen = 4096;
+    static uint8_t buf[buflen] = {0};
+
+    while (1) {
+        bool did_something = false;
+        // Lame replacement for blocking IO. We can't just wait and tell the
+        // scheduler to go work on something else while we wait for packets so
+        // instead, if we're getting nothing in and have nothing to send, block
+        // ourselves.
+
+        // Writing
+        if (self.write_packet_if_avail()) {
+            did_something = true;
+        }
+
+        // Reading
+        const int avail = vexGenericSerialReceiveAvail(self.port);
+        if (avail > 0) {
+            const int read = vexGenericSerialReceive(self.port, buf, buflen);
+            if (read > 0 && read < (int)buflen) {
+
+                self.inbound_mutex.lock();
+                for (int i = 0; i < read; i++) {
+                    self.handle_inbound_byte(buf[i]);
+                }
+                self.inbound_mutex.unlock();
+            }
+            did_something = true;
+        }
+
+        if (!did_something) {
+            vexDelay(NO_ACTIVITY_DELAY_MS);
+        }
+    }
+    return 0;
+}
+
+bool COBSSerialDevice::send_cobs_packet(const Packet &pac) {
+    outbound_mutex.lock();
+    size_t size = outbound_packets.size();
+    outbound_mutex.unlock();
+    if (size >= MAX_OUT_QUEUE_SIZE) {
+        // printf("Too many packets in out queue. dropping\n");
+        return false;
+    }
+
+    std::vector<uint8_t> encoded;
+    cobs_encode(pac, encoded, false);
+
+    printf("\nEncoded:\n");
+    for (int i = 0; i < encoded.size(); i++) {
+        printf("%02x ", encoded[i]);
+    }
+    printf("\n");
+
+    outbound_mutex.lock();
+    outbound_packets.push_front(encoded);
+    outbound_mutex.unlock();
+    return true;
+}
+
+void COBSSerialDevice::cobs_encode(const Packet &in, WirePacket &out, bool add_start_delimeter) {
+    out.clear();
+    if (in.size() == 0) {
+        return;
+    }
+    size_t output_size = in.size() + (in.size() / 254) + 1;
+    output_size += 1 + (add_start_delimeter ? 1 : 0); // delimeter bytes
+    out.resize(output_size);
+
+    size_t output_code_head = 0;
+    if (add_start_delimeter) {
+        out[0] = 0;
+        output_code_head = 1;
+    }
+
+    size_t code_value = 1;
+
+    size_t input_head = 0;
+    size_t output_head = (add_start_delimeter ? 2 : 1);
+    size_t length = 0;
+    while (input_head < in.size()) {
+        if (in[input_head] == 0 || length == 255) {
+            out[output_code_head] = (uint8_t)code_value;
+            code_value = 1;
+            output_code_head = output_head;
+            length = 0;
+            output_head++;
+            if (in[input_head] == 0) {
+                input_head++;
+            }
+        } else {
+            out[output_head] = in[input_head];
+            code_value++;
+            input_head++;
+            output_head++;
+        }
+        length++;
+    }
+    out[output_code_head] = code_value;
+
+    // Trailing delimeter
+    out[output_head] = 0;
+    output_head++;
+
+    out.resize(output_head);
+}
+
+void COBSSerialDevice::cobs_decode(const WirePacket &in, Packet &out) {
+    out.clear();
+    if (in.size() == 0) {
+        return;
+    }
+
+    out.resize(in.size() + in.size() / 254);
+    uint8_t code = 0xff;
+    uint8_t left_in_block = 0;
+    size_t write_head = 0;
+    for (const uint8_t byte : in) {
+        if (left_in_block) {
+            out[write_head] = byte;
+            write_head++;
+        } else {
+            left_in_block = byte;
+            if (left_in_block != 0 && (code != 0xff)) {
+                out[write_head] = 0;
+                write_head++;
+            }
+            code = left_in_block;
+            if (code == 0) {
+                // hit a delimeter
+                break;
+            }
+        }
+        left_in_block--;
+    }
+    out.resize(write_head);
+
+    return;
+}

--- a/src/devices/cobs_serial_device.cpp
+++ b/src/devices/cobs_serial_device.cpp
@@ -129,23 +129,16 @@ int COBSSerialDevice::serial_thread(void *vself) {
     return 0;
 }
 
-bool COBSSerialDevice::send_cobs_packet(const Packet &pac) {
+bool COBSSerialDevice::send_cobs_packet(const Packet &pac, bool add_front_delimeter) {
     outbound_mutex.lock();
     size_t size = outbound_packets.size();
     outbound_mutex.unlock();
     if (size >= MAX_OUT_QUEUE_SIZE) {
-        // printf("Too many packets in out queue. dropping\n");
         return false;
     }
 
     std::vector<uint8_t> encoded;
-    cobs_encode(pac, encoded, false);
-
-    printf("\nEncoded:\n");
-    for (int i = 0; i < encoded.size(); i++) {
-        printf("%02x ", encoded[i]);
-    }
-    printf("\n");
+    cobs_encode(pac, encoded, add_front_delimeter);
 
     outbound_mutex.lock();
     outbound_packets.push_front(encoded);


### PR DESCRIPTION
# Description
Introduces a generic CobsSerialDevice for interacting with external sensors (Interface Board, Debug Board)

Uses [COBS](https://en.wikipedia.org/wiki/Consistent_Overhead_Byte_Stuffing) to packetize and deliver data to the peripheral. 

**HERE BE DRAGONS** :dragon: theres no flow control so you have to do that in software :wa:. 

# Usage

How to use this feature:

Implement a class that inherits from `CobsSerialDevice`. Override the `cobs_packet_callback` method to receive 
```c++
class SillyDevice : public CobsSerialDevice{
     SillyDevice(int32_t port, int32_t baud): CobsSerialDevice(port, baud){}

    void cobs_packet_callback(const COBSSerialDevice::Packet &pac) override {
        printf("Received Packet:\n");
        for (size_t i = 0; i < pac.size(); i++){
             printf("%02x ", pac[i]);
        }
        printf("\n");
    }
}
```
`CobsSerialDevice` also exposes a `send_cobs_packet` method which will encode data and send it to the device. 

# Testing

Tested against the InterfaceBoard Code as of the WV comp ([commit here](https://github.com/RIT-VEX-U/VexInterfaceBoard/commit/9d912ddb779e96748972d012379f140493e18ef7))

# References

- https://en.wikipedia.org/wiki/Consistent_Overhead_Byte_Stuffing
- See notebook entries on Debug Board and Interface Board
