### PR TITLE
Interpolating Map

### DIFF
--- a/include/utils/interpolating_map.h
+++ b/include/utils/interpolating_map.h
@@ -1,0 +1,68 @@
+#pragma once
+
+#include <map>
+
+#include "../core/include/utils/math/eigen_interface.h"
+
+/**
+ * This class implements a map of key-value pairs.
+ * 
+ * If there is not a pair with the given key in the map, the value will be a
+ * linear interpolation of the preceding and following values.
+ * 
+ * @tparam KEY The type of the key.
+ * @tparam VALUE The type of the value.
+ */
+template <typename KEY, typename VALUE> class InterpolatingMap {
+  public:
+    using MapType = std::map<KEY, VALUE, std::less<KEY>, Eigen::aligned_allocator<std::pair<const KEY, VALUE>>>;
+
+    /**
+     * Inserts a key value pair.
+     * 
+     * @param key The key.
+     * @param vlue The value.
+     */
+    void insert(const KEY &key, const VALUE &value) { map_.insert({key, value}); }
+
+    /**
+     * Obtains the value at the given key.
+     * 
+     * If the key does not exactly match a pair in the map, it will interpolate
+     * between the preceding and following pairs.
+     * 
+     * @param key The key.
+     * 
+     * @return The value.
+     */
+    VALUE operator[](const KEY &key) {
+        // Get iterator for the upper bound of our key.
+        typename MapType::const_iterator upper = map_.upper_bound(key);
+
+        // If our key greater than the largest key return its value.
+        if (upper == map_.end()) {
+            return (--upper)->second;
+        }   
+
+        // If our key less than or equal to the smallest key return its value.
+        if (upper == map_.begin()) {
+            return upper->second;
+        }
+
+        // Get an iterator to the previous entry.
+        typename MapType::const_iterator lower = upper;
+        --lower;
+
+        // Linear interpolate between the values of the first and second.
+        const double delta = (key - lower->first) / (upper->first - lower->first);
+        return delta * upper->second + (1.0 - delta) * lower->second;
+    }
+
+    /**
+     * Clears the contents of the map.
+     */
+    void clear() { map_.clear(); }
+
+  private:
+    MapType map_;
+};

--- a/include/utils/math/eigen_interface.h
+++ b/include/utils/math/eigen_interface.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <Eigen/Dense>
+
+/**
+ * This header only serves to let you use Eigen's vectors and matrices without
+ * having to write out
+ * Eigen::Vector<double, DIM>
+ * Eigen::Matrix<double, ROWS, COLS>
+ * 
+ * include this and use:
+ * EVec<DIM>
+ * EMAT<ROWS, COLS>
+ */
+
+template <int DIM>
+using EVec = Eigen::Vector<double, DIM>;
+
+template <int ROWS, int COLS>
+using EMat = Eigen::Matrix<double, ROWS, COLS>;


### PR DESCRIPTION
Another wpilib classic, have you ever wanted to interpolate between things that shouldn't be interpolated?? vectors? matrices?? use this!!!

# Description
It's a map, you insert key-value pairs and you get the value by telling it a key. This one is special because it linearly interpolates between values if you put in a key that isn't in the map.

# Usage
```cpp
InterpolatingMap<double, EVec<2>> map;

map.insert(0, EVec<2>{1, 1});
map.insert(1, EVec<2>{2, 2});

std::cout << map[0.5] << std::endl;
```

```
1.5
1.5
```

# Testing

I tried it with double and vector and matrix and it worked

# References
https://eigen.tuxfamily.org/dox/group__TopicStlContainers.html
sobbing